### PR TITLE
fix: tweaks and bugfix

### DIFF
--- a/src/BestWordle.js
+++ b/src/BestWordle.js
@@ -6,7 +6,6 @@ module.exports = {
     const excludeLetters = 'arsblodfght'.split('');
     const includeLetters = 'ceni'.split('');
 
-    // let words = data.split("\n");
     const YELLOW_POINTS = 1;
     const GREEN_POINTS = 10;
 
@@ -22,8 +21,8 @@ module.exports = {
 
         const otherLetters = otherWord.split('');
 
-        // processing greens
         letters.forEach((l, i) => {
+          // processing yellows
           if (
             otherWord.includes(l)
             && !excludeLetters.includes(otherWord[i])
@@ -31,10 +30,8 @@ module.exports = {
           ) {
             score[i] = YELLOW_POINTS;
           }
-        });
 
-        // processing greens
-        letters.forEach((l, i) => {
+          // processing greens
           if (
             l === otherLetters[i]
             && !excludeLetters.includes(otherWord[i])

--- a/src/solver.js
+++ b/src/solver.js
@@ -34,11 +34,10 @@ fs.readFile(wordsLargePath, 'utf8', (err, data) => {
     throw err;
   }
 
+  const words = data.split('\n');
   const greenMatches = [];
   const guessedLettersMatching = [];
   const guessedLettersNonMatching = [];
-
-  const words = data.split('\n');
   const guesses = [];
 
   for (;;) {


### PR DESCRIPTION
Some efficiency tweaks by joining checks into the same loop.

---

There was a bug I noticed when running wordle more than once:
```
Wordle word? solve
Wordle info (y/g/0): g0y0g
solve g0y0g
[
  { word: 'sline', average: 13.085714285714285 },
  { word: 'slice', average: 12.8 },
  { word: 'slide', average: 12.8 },
  { word: 'slime', average: 12.8 },
  { word: 'slipe', average: 12.8 },
  { word: 'slite', average: 12.8 },
  { word: 'spile', average: 12.714285714285714 },
  { word: 'smile', average: 12.685714285714285 },
  { word: 'stile', average: 12.685714285714285 },
  { word: 'swile', average: 12.685714285714285 }
]
Wordle word? slice
Wordle info (y/g/0): gy00g
slice gy00g
[
  { word: 'salue', average: 10.125 },
  ***{ word: 'slade', average: 10.125 },***
  ***{ word: 'slake', average: 10.125 },***
  ***{ word: 'slane', average: 10.125 },***
  { word: 'slape', average: 10.125 },
  { word: 'slare', average: 10.125 },
  { word: 'slate', average: 10.125 },
  { word: 'slyke', average: 10.125 },
  { word: 'slype', average: 10.125 },
  { word: 'sable', average: 10.083333333333334 }
]
```

We declared slice with gy00g, but s**l**ade was being returned. This is due to `yellowMatches` having references to the old word, so the quickest fix is to redeclare that array inside the loop.